### PR TITLE
프로필 사진 크기 고정하기

### DIFF
--- a/src/components/Users.jsx
+++ b/src/components/Users.jsx
@@ -101,7 +101,7 @@ export default function Users() {
               <Item key={user.id}>
                 <Wrapper>
                   <Link to={`/users/${user.id}`}>
-                    <Image alt="avatar" src={user.imageUrl} />
+                    <Image alt="avatar" src={user.imageUrl} width={75} height={75} />
                   </Link>
                   <div>
                     <StyledLink to={`/users/${user.id}`}>


### PR DESCRIPTION
프로필 사진 크기가 고정되어 있지 않아 레이아웃이 어긋나서
사람들 페이지의 프로필 사진 크기를 고정했다.